### PR TITLE
docs: add inline comments to bootstrap_dev.yml for new users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - `ROADMAP.md` — DC1 strategic roadmap capturing architecture layers, migration sequence, phase plan, known F5 issues, and related repos
 - `playbooks/bootstrap_dev.yml` — automates Phase 1 dev environment setup (Hub credentials, Vault credential, project, job template) against a fresh AAP instance
+- Inline comments in `bootstrap_dev.yml` guide new users on where to store their Automation Hub token (`~/.ansible/ansible.cfg`), vault password (`~/.ansible/secrets2`), and how to host their remote vault and SSH key files
 - `docs/dev-environment.md` — local dev credentials file (excluded from git via .gitignore)
 
 ### Changed

--- a/playbooks/bootstrap_dev.yml
+++ b/playbooks/bootstrap_dev.yml
@@ -8,10 +8,24 @@
     controller_username: "{{ lookup('ansible.builtin.env', 'CONTROLLER_USERNAME') }}"
     controller_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"
     controller_validate_certs: false
-    hub_token: "{{ lookup('ini', 'token section=galaxy_server.rh_certified file=/home/eames/.ansible/ansible.cfg') }}"
-    vault_password: "{{ lookup('ansible.builtin.file', '/home/eames/.ansible/secrets2') | trim }}"
+    # Automation Hub API token — obtain from Red Hat Console:
+    # console.redhat.com → Automation Hub → Connect to Hub → API token
+    # Store it in your local ansible.cfg under [galaxy_server.rh_certified] and
+    # [galaxy_server.rh_validated] as: token=<your_token>
+    # Example path: /home/<your_username>/.ansible/ansible.cfg
+    hub_token: "{{ lookup('ini', 'token section=galaxy_server.rh_certified file=~/.ansible/ansible.cfg') }}"
+    # Vault password — the default_password for your AAP vault credential.
+    # Store it as a single line of text in a local secrets file.
+    # Example path: /home/<your_username>/.ansible/secrets2
+    vault_password: "{{ lookup('ansible.builtin.file', '~/.ansible/secrets2') | trim }}"
     hub_auth_url: "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
+    # Remote vault URL — a raw URL to a YAML file containing your AAP secrets
+    # (default_passwd, ssh_priv_key, registry tokens, etc.).
+    # Host this file in a private repo and reference the raw content URL.
+    # Example: https://raw.githubusercontent.com/<your_org>/sourcefiles/main/vault_<your_name>.yml
     my_remote_vault: "https://raw.githubusercontent.com/ericcames/sourcefiles/refs/heads/main/vault_ames.yml"
+    # Remote SSH public key URL — raw URL to your id_rsa.pub hosted in the same private repo.
+    # Example: https://raw.githubusercontent.com/<your_org>/sourcefiles/main/id_rsa.pub
     my_remote_ssh_pub_key: "https://raw.githubusercontent.com/ericcames/sourcefiles/refs/heads/main/id_rsa.pub"
 
   tasks:


### PR DESCRIPTION
## Summary
- Adds inline comments at each user-specific variable in `bootstrap_dev.yml`
- Documents where to get the Automation Hub token (Red Hat Console → Automation Hub → Connect to Hub)
- Documents where to store it locally (`~/.ansible/ansible.cfg` under `[galaxy_server.rh_certified]`)
- Documents where to store the vault password (`~/.ansible/secrets2`)
- Documents how to host `my_remote_vault` and `my_remote_ssh_pub_key` in a private GitHub repo
- Switches hardcoded `/home/eames/` paths to `~` so the playbook works for any user

## Test Plan
- [ ] Review comments are clear and actionable for a new user
- [ ] Verify `~` path expansion works on a fresh run

🤖 Generated with [Claude Code](https://claude.com/claude-code)