### PR TITLE
docs: add CLAUDE.md with new environment setup guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `CLAUDE.md` — Claude-specific guidelines covering new AAP environment setup, bootstrap playbook usage, collection install steps, key files, and project conventions
+
+### Added
 - `ROADMAP.md` — DC1 strategic roadmap capturing architecture layers, migration sequence, phase plan, known F5 issues, and related repos
 - `playbooks/bootstrap_dev.yml` — automates Phase 1 dev environment setup (Hub credentials, Vault credential, project, job template) against a fresh AAP instance
 - Inline comments in `bootstrap_dev.yml` guide new users on where to store their Automation Hub token (`~/.ansible/ansible.cfg`), vault password (`~/.ansible/secrets2`), and how to host their remote vault and SSH key files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# aap.as.code — Claude Guidelines
+
+## Working with a New AAP Environment
+
+When a user provides a new AAP URL and password, update `docs/dev-environment.md`
+with the new values before running anything. This file is excluded from git — never
+commit credentials and never share them in chat.
+
+```
+docs/dev-environment.md
+├── URL      → new AAP instance URL
+├── Username → admin (default)
+└── Password → provided password
+```
+
+## Bootstrapping a Fresh AAP Instance
+
+A fresh AAP instance has none of the required credentials, projects, or job templates.
+Run `playbooks/bootstrap_dev.yml` first — it creates the prerequisites automatically.
+
+### Prerequisites (one-time local setup)
+
+Install the required collections locally before running the playbook:
+
+```bash
+ANSIBLE_CONFIG=~/.ansible/ansible.cfg \
+  ansible-galaxy collection install ansible.platform ansible.controller \
+  -p ./collections
+```
+
+Your `~/.ansible/ansible.cfg` must have a valid Automation Hub token under
+`[galaxy_server.rh_certified]`. Obtain it from:
+`console.redhat.com → Automation Hub → Connect to Hub → API token`
+
+### Running the Bootstrap
+
+```bash
+export CONTROLLER_HOST=<new AAP URL>
+export CONTROLLER_USERNAME=admin
+export CONTROLLER_PASSWORD=<new password>
+ansible-playbook playbooks/bootstrap_dev.yml
+```
+
+The playbook creates:
+- Automation Hub certified and validated credentials
+- Galaxy credentials associated with the Default Organization
+- Eric Ames vault credential (reads password from `~/.ansible/secrets2`)
+- `aap.as.code` project
+- `Setup - AAP - CAC` job template
+
+The bootstrap token is automatically deleted when the playbook completes
+(even on failure) to prevent stale token accumulation.
+
+### After Bootstrap — Run Setup
+
+Once bootstrap completes, launch `Setup - AAP - CAC` from AAP to load all
+demo configurations via CaC.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `playbooks/bootstrap_dev.yml` | Automates Phase 1 AAP setup from localhost |
+| `playbooks/main.yml` | Main CaC setup playbook (runs inside AAP) |
+| `docs/dev-environment.md` | Local dev credentials — gitignored, never commit |
+| `ROADMAP.md` | DC1 strategic roadmap and migration status |
+| `CHANGELOG.md` | Record of all changes — always update before committing |
+
+## Conventions
+
+- Always update `CHANGELOG.md` before committing changes
+- Document issues in GitHub before making fixes
+- One fix per branch and PR
+- Use `ansible.platform` modules where available; fall back to `ansible.controller`
+  only when no platform equivalent exists
+- Any playbook that creates a token must delete it in an `always:` block

--- a/playbooks/bootstrap_dev.yml
+++ b/playbooks/bootstrap_dev.yml
@@ -55,10 +55,10 @@
       block:
 
         - name: Create Automation Hub - certified credential
-          ansible.platform.credential:
-            aap_hostname: "{{ aap_hostname }}"
-            aap_token: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
-            aap_validate_certs: "{{ aap_validate_certs }}"
+          ansible.controller.credential:
+            controller_host: "{{ aap_hostname }}"
+            controller_oauthtoken: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
+            validate_certs: "{{ aap_validate_certs }}"
             name: "Automation Hub - certified"
             organization: Default
             credential_type: "Ansible Galaxy/Automation Hub API Token"
@@ -69,10 +69,10 @@
             state: present
 
         - name: Create Automation Hub - validated credential
-          ansible.platform.credential:
-            aap_hostname: "{{ aap_hostname }}"
-            aap_token: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
-            aap_validate_certs: "{{ aap_validate_certs }}"
+          ansible.controller.credential:
+            controller_host: "{{ aap_hostname }}"
+            controller_oauthtoken: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
+            validate_certs: "{{ aap_validate_certs }}"
             name: "Automation Hub - validated"
             organization: Default
             credential_type: "Ansible Galaxy/Automation Hub API Token"
@@ -83,10 +83,10 @@
             state: present
 
         - name: Associate Galaxy credentials with Default Organization
-          ansible.platform.organization:
-            aap_hostname: "{{ aap_hostname }}"
-            aap_token: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
-            aap_validate_certs: "{{ aap_validate_certs }}"
+          ansible.controller.organization:
+            controller_host: "{{ aap_hostname }}"
+            controller_oauthtoken: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
+            validate_certs: "{{ aap_validate_certs }}"
             name: Default
             galaxy_credentials:
               - "Automation Hub - certified"
@@ -94,10 +94,10 @@
             state: present
 
         - name: Create Eric Ames vault credential
-          ansible.platform.credential:
-            aap_hostname: "{{ aap_hostname }}"
-            aap_token: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
-            aap_validate_certs: "{{ aap_validate_certs }}"
+          ansible.controller.credential:
+            controller_host: "{{ aap_hostname }}"
+            controller_oauthtoken: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
+            validate_certs: "{{ aap_validate_certs }}"
             name: "Eric Ames"
             organization: Default
             credential_type: "Vault"
@@ -106,10 +106,10 @@
             state: present
 
         - name: Create aap.as.code project
-          ansible.platform.project:
-            aap_hostname: "{{ aap_hostname }}"
-            aap_token: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
-            aap_validate_certs: "{{ aap_validate_certs }}"
+          ansible.controller.project:
+            controller_host: "{{ aap_hostname }}"
+            controller_oauthtoken: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
+            validate_certs: "{{ aap_validate_certs }}"
             name: "aap.as.code"
             organization: Default
             scm_type: git
@@ -120,10 +120,10 @@
             state: present
 
         - name: Create Setup - AAP - CAC job template
-          ansible.platform.job_template:
-            aap_hostname: "{{ aap_hostname }}"
-            aap_token: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
-            aap_validate_certs: "{{ aap_validate_certs }}"
+          ansible.controller.job_template:
+            controller_host: "{{ aap_hostname }}"
+            controller_oauthtoken: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
+            validate_certs: "{{ aap_validate_certs }}"
             name: "Setup - AAP - CAC"
             organization: Default
             inventory: "Demo Inventory"


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` at the repo root with guidance for Claude users working with new AAP instances
- Documents the `bootstrap_dev.yml` workflow: prerequisites, collection install, env vars, what it creates
- Explains the `docs/dev-environment.md` credential pattern (never share in chat, never commit)
- Lists key files and project conventions (changelog, one PR per fix, ansible.platform preference, token cleanup)
- Also carries forward the working `bootstrap_dev.yml` fix (`ansible.controller` with `controller_oauthtoken` for credential/project/job_template, `ansible.platform.token` for token lifecycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)