### PR TITLE
fix: correct bootstrap_dev.yml module and parameter usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - Inline comments in `bootstrap_dev.yml` guide new users on where to store their Automation Hub token (`~/.ansible/ansible.cfg`), vault password (`~/.ansible/secrets2`), and how to host their remote vault and SSH key files
 
 ### Changed
-- `playbooks/bootstrap_dev.yml` — migrated from `ansible.controller` to `ansible.platform` modules; bootstrap token is now created at start and deleted in an `always:` block to prevent stale token accumulation
+- `playbooks/bootstrap_dev.yml` — corrected module usage: `ansible.controller` with `controller_oauthtoken` for credential/organization/project/job_template (no `ansible.platform` equivalents exist); `ansible.platform.token` used for token lifecycle only
 - `docs/dev-environment.md` — local dev credentials file (excluded from git via .gitignore)
 
 ### Changed

--- a/playbooks/bootstrap_dev.yml
+++ b/playbooks/bootstrap_dev.yml
@@ -55,10 +55,10 @@
       block:
 
         - name: Create Automation Hub - certified credential
-          ansible.platform.credential:
-            aap_hostname: "{{ aap_hostname }}"
-            aap_token: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
-            aap_validate_certs: "{{ aap_validate_certs }}"
+          ansible.controller.credential:
+            controller_host: "{{ aap_hostname }}"
+            controller_oauthtoken: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
+            validate_certs: "{{ aap_validate_certs }}"
             name: "Automation Hub - certified"
             organization: Default
             credential_type: "Ansible Galaxy/Automation Hub API Token"
@@ -69,10 +69,10 @@
             state: present
 
         - name: Create Automation Hub - validated credential
-          ansible.platform.credential:
-            aap_hostname: "{{ aap_hostname }}"
-            aap_token: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
-            aap_validate_certs: "{{ aap_validate_certs }}"
+          ansible.controller.credential:
+            controller_host: "{{ aap_hostname }}"
+            controller_oauthtoken: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
+            validate_certs: "{{ aap_validate_certs }}"
             name: "Automation Hub - validated"
             organization: Default
             credential_type: "Ansible Galaxy/Automation Hub API Token"
@@ -83,10 +83,10 @@
             state: present
 
         - name: Associate Galaxy credentials with Default Organization
-          ansible.platform.organization:
-            aap_hostname: "{{ aap_hostname }}"
-            aap_token: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
-            aap_validate_certs: "{{ aap_validate_certs }}"
+          ansible.controller.organization:
+            controller_host: "{{ aap_hostname }}"
+            controller_oauthtoken: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
+            validate_certs: "{{ aap_validate_certs }}"
             name: Default
             galaxy_credentials:
               - "Automation Hub - certified"
@@ -94,10 +94,10 @@
             state: present
 
         - name: Create Eric Ames vault credential
-          ansible.platform.credential:
-            aap_hostname: "{{ aap_hostname }}"
-            aap_token: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
-            aap_validate_certs: "{{ aap_validate_certs }}"
+          ansible.controller.credential:
+            controller_host: "{{ aap_hostname }}"
+            controller_oauthtoken: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
+            validate_certs: "{{ aap_validate_certs }}"
             name: "Eric Ames"
             organization: Default
             credential_type: "Vault"
@@ -106,10 +106,10 @@
             state: present
 
         - name: Create aap.as.code project
-          ansible.platform.project:
-            aap_hostname: "{{ aap_hostname }}"
-            aap_token: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
-            aap_validate_certs: "{{ aap_validate_certs }}"
+          ansible.controller.project:
+            controller_host: "{{ aap_hostname }}"
+            controller_oauthtoken: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
+            validate_certs: "{{ aap_validate_certs }}"
             name: "aap.as.code"
             organization: Default
             scm_type: git
@@ -120,10 +120,10 @@
             state: present
 
         - name: Create Setup - AAP - CAC job template
-          ansible.platform.job_template:
-            aap_hostname: "{{ aap_hostname }}"
-            aap_token: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
-            aap_validate_certs: "{{ aap_validate_certs }}"
+          ansible.controller.job_template:
+            controller_host: "{{ aap_hostname }}"
+            controller_oauthtoken: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
+            validate_certs: "{{ aap_validate_certs }}"
             name: "Setup - AAP - CAC"
             organization: Default
             inventory: "Demo Inventory"


### PR DESCRIPTION
## Summary
Fixes incorrect module usage introduced in PR #142.

`ansible.platform` only provides gateway-level modules (`token`, `organization`, `user`, `team`). The modules `credential`, `project`, and `job_template` do not exist in `ansible.platform` — they must use `ansible.controller` with `controller_oauthtoken`.

## Changes
- `ansible.platform.credential` → `ansible.controller.credential`
- `ansible.platform.organization` → `ansible.controller.organization`
- `ansible.platform.project` → `ansible.controller.project`
- `ansible.platform.job_template` → `ansible.controller.job_template`
- Parameter `aap_token` → `controller_oauthtoken` on all `ansible.controller` calls
- `ansible.platform.token` retained for token lifecycle (correct)

## Validation
Bootstrap ran successfully against dev AAP with these corrections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)