### PR TITLE
fix: set scm_branch to main in bootstrap_dev.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- `playbooks/bootstrap_dev.yml` — changed `scm_branch` from hardcoded `ericames/productdemo` to `main` (fixes #150)
+
 ### Changed
 - `ROADMAP.md` — marked issues #14, #18, #21, #23 resolved in Phase 1 checklist and Known Issues table; added issue links
 

--- a/playbooks/bootstrap_dev.yml
+++ b/playbooks/bootstrap_dev.yml
@@ -114,7 +114,7 @@
             organization: Default
             scm_type: git
             scm_url: "https://github.com/ericcames/aap.as.code.git"
-            scm_branch: ericames/productdemo
+            scm_branch: main
             scm_update_on_launch: true
             wait: true
             state: present


### PR DESCRIPTION
## Summary
- Fixes hardcoded `scm_branch: ericames/productdemo` → `scm_branch: main` in `playbooks/bootstrap_dev.yml`
- Closes #150

## Test plan
- [ ] Run `bootstrap_dev.yml` against a fresh AAP instance and verify the `aap.as.code` project syncs from `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)