### PR TITLE
refactor: make bootstrap_dev.yml inventory-driven

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- `playbooks/bootstrap_dev.yml` — refactored to be inventory-driven; all environment vars moved to `inventories/rhdp-<customer>-<demo>/group_vars/all.yml` (closes #152)
+- `playbooks/bootstrap_dev.yml` — changed `hosts: localhost` to `hosts: all` to support inventory targeting
+
+### Added
+- `inventories/rhdp-sample-demo/` — sample inventory template for new RHDP environments; copy and rename for each customer/demo combination
+
 ### Fixed
 - `playbooks/bootstrap_dev.yml` — changed `scm_branch` from hardcoded `ericames/productdemo` to `main` (fixes #150)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- `playbooks/bootstrap_dev.yml` — changed `scm_branch` from hardcoded `ericames/productdemo` to `main` (fixes #150)
+
 ### Changed
 - `ROADMAP.md` — marked issues #14, #18, #21, #23 resolved in Phase 1 checklist and Known Issues table; added issue links
 

--- a/inventories/rhdp-sample-demo/group_vars/all.yml
+++ b/inventories/rhdp-sample-demo/group_vars/all.yml
@@ -1,0 +1,26 @@
+---
+# RHDP environment: rhdp-sample-demo
+# Copy this inventory to inventories/rhdp-<customer>-<demo>/ for each environment.
+# No secrets are stored here — all sensitive values are resolved at runtime via lookups.
+#
+# Before running:
+#   export CONTROLLER_HOST=<aap url from rhdp services page>
+#   export CONTROLLER_USERNAME=admin
+#   export CONTROLLER_PASSWORD=<password from rhdp services page>
+#
+# Automation Hub token must be in ~/.ansible/ansible.cfg under [galaxy_server.rh_certified]
+# Vault password must be a single line in ~/.ansible/secrets2
+
+aap_hostname: "{{ lookup('ansible.builtin.env', 'CONTROLLER_HOST') }}"
+aap_username: "{{ lookup('ansible.builtin.env', 'CONTROLLER_USERNAME') }}"
+aap_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"
+aap_validate_certs: false
+
+hub_token: "{{ lookup('ini', 'token section=galaxy_server.rh_certified file=~/.ansible/ansible.cfg') }}"
+vault_password: "{{ lookup('ansible.builtin.file', '~/.ansible/secrets2') | trim }}"
+hub_auth_url: "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
+
+# Remote vault and SSH key — host these in a private repo and set the raw content URLs below.
+# Example: https://raw.githubusercontent.com/<your_org>/sourcefiles/main/vault_<your_name>.yml
+my_remote_vault: ""
+my_remote_ssh_pub_key: ""

--- a/inventories/rhdp-sample-demo/hosts
+++ b/inventories/rhdp-sample-demo/hosts
@@ -1,0 +1,2 @@
+[all]
+localhost ansible_connection=local ansible_python_interpreter=/usr/bin/python3

--- a/playbooks/bootstrap_dev.yml
+++ b/playbooks/bootstrap_dev.yml
@@ -1,32 +1,9 @@
 ---
 - name: Bootstrap AAP Dev Environment
-  hosts: localhost
+  hosts: all
   gather_facts: false
-  vars:
-    ansible_python_interpreter: /usr/bin/python3
-    aap_hostname: "{{ lookup('ansible.builtin.env', 'CONTROLLER_HOST') }}"
-    aap_username: "{{ lookup('ansible.builtin.env', 'CONTROLLER_USERNAME') }}"
-    aap_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"
-    aap_validate_certs: false
-    # Automation Hub API token — obtain from Red Hat Console:
-    # console.redhat.com → Automation Hub → Connect to Hub → API token
-    # Store it in your local ansible.cfg under [galaxy_server.rh_certified] and
-    # [galaxy_server.rh_validated] as: token=<your_token>
-    # Example path: /home/<your_username>/.ansible/ansible.cfg
-    hub_token: "{{ lookup('ini', 'token section=galaxy_server.rh_certified file=~/.ansible/ansible.cfg') }}"
-    # Vault password — the default_password for your AAP vault credential.
-    # Store it as a single line of text in a local secrets file.
-    # Example path: /home/<your_username>/.ansible/secrets2
-    vault_password: "{{ lookup('ansible.builtin.file', '~/.ansible/secrets2') | trim }}"
-    hub_auth_url: "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
-    # Remote vault URL — a raw URL to a YAML file containing your AAP secrets
-    # (default_passwd, ssh_priv_key, registry tokens, etc.).
-    # Host this file in a private repo and reference the raw content URL.
-    # Example: https://raw.githubusercontent.com/<your_org>/sourcefiles/main/vault_<your_name>.yml
-    my_remote_vault: "https://raw.githubusercontent.com/ericcames/sourcefiles/refs/heads/main/vault_ames.yml"
-    # Remote SSH public key URL — raw URL to your id_rsa.pub hosted in the same private repo.
-    # Example: https://raw.githubusercontent.com/<your_org>/sourcefiles/main/id_rsa.pub
-    my_remote_ssh_pub_key: "https://raw.githubusercontent.com/ericcames/sourcefiles/refs/heads/main/id_rsa.pub"
+  # All variables are defined in inventories/rhdp-<customer>-<demo>/group_vars/all.yml
+  # Run with: ansible-playbook -i inventories/rhdp-<customer>-<demo>/ playbooks/bootstrap_dev.yml
 
   tasks:
 

--- a/playbooks/bootstrap_dev.yml
+++ b/playbooks/bootstrap_dev.yml
@@ -114,7 +114,7 @@
             organization: Default
             scm_type: git
             scm_url: "https://github.com/ericcames/aap.as.code.git"
-            scm_branch: ericames/productdemo
+            scm_branch: main
             scm_update_on_launch: true
             wait: true
             state: present


### PR DESCRIPTION
## Summary
- Moves all environment-specific vars out of `bootstrap_dev.yml` into `inventories/rhdp-<customer>-<demo>/group_vars/all.yml`
- Adds `inventories/rhdp-sample-demo/` as a template for new environments
- Playbook is now environment-agnostic — target any environment by pointing at its inventory
- Closes #152

## Usage after this change
```bash
ansible-playbook -i inventories/rhdp-acme-f5demo/ playbooks/bootstrap_dev.yml
```

## Test plan
- [ ] Copy `inventories/rhdp-sample-demo/` to a new inventory name
- [ ] Set `CONTROLLER_HOST`, `CONTROLLER_USERNAME`, `CONTROLLER_PASSWORD` env vars
- [ ] Run bootstrap against the new inventory and verify AAP objects are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)