### PR TITLE
docs: update CLAUDE.md and README.md for inventory-driven bootstrap and skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- `CLAUDE.md` — updated bootstrap command to use `-i inventories/rhdp-<customer>-<demo>/`; added Claude Code Skills section with install instructions and skill reference (closes #154)
+- `CLAUDE.md` — updated Key Files table to include `inventories/rhdp-sample-demo/`
+- `README.md` — added Automated Bootstrap section referencing `/aap-bootstrap` and `/aap-setup-demo` skills
+
 ### Fixed
 - `playbooks/bootstrap_dev.yml` — changed `scm_branch` from hardcoded `ericames/productdemo` to `main` (fixes #150)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,12 +34,18 @@ Your `~/.ansible/ansible.cfg` must have a valid Automation Hub token under
 
 ### Running the Bootstrap
 
+Each environment gets its own named inventory. Copy the sample and set env vars:
+
 ```bash
+cp -r inventories/rhdp-sample-demo/ inventories/rhdp-<customer>-<demo>/
 export CONTROLLER_HOST=<new AAP URL>
 export CONTROLLER_USERNAME=admin
 export CONTROLLER_PASSWORD=<new password>
-ansible-playbook playbooks/bootstrap_dev.yml
+ansible-playbook -i inventories/rhdp-<customer>-<demo>/ playbooks/bootstrap_dev.yml
 ```
+
+The inventory `group_vars/all.yml` resolves all sensitive values at runtime via
+env var and file lookups — no secrets are stored in the inventory.
 
 The playbook creates:
 - Automation Hub certified and validated credentials
@@ -56,12 +62,35 @@ The bootstrap token is automatically deleted when the playbook completes
 Once bootstrap completes, launch `Setup - AAP - CAC` from AAP to load all
 demo configurations via CaC.
 
+## Claude Code Skills
+
+Two skills automate the bootstrap workflow inside Claude Code. Install them once:
+
+```bash
+claude plugins marketplace add ericcames/aap-skills
+claude plugins install aap-skills
+```
+
+| Skill | Command | Purpose |
+|-------|---------|---------|
+| aap-bootstrap | `/aap-bootstrap` | Collect credentials, generate inventory, run bootstrap — stops when AAP is ready |
+| aap-setup-demo | `/aap-setup-demo` | Everything above, then launches `Setup - AAP - CAC` as a live demo story |
+
+Skills are published at [github.com/ericcames/aap-skills](https://github.com/ericcames/aap-skills).
+Update to the latest version with:
+
+```bash
+claude plugins marketplace update aap-skills
+claude plugins update aap-skills@aap-skills
+```
+
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `playbooks/bootstrap_dev.yml` | Automates Phase 1 AAP setup from localhost |
+| `playbooks/bootstrap_dev.yml` | Inventory-driven bootstrap playbook — run with `-i inventories/rhdp-<customer>-<demo>/` |
 | `playbooks/main.yml` | Main CaC setup playbook (runs inside AAP) |
+| `inventories/rhdp-sample-demo/` | Sample inventory template — copy for each new environment |
 | `docs/dev-environment.md` | Local dev credentials — gitignored, never commit |
 | `ROADMAP.md` | DC1 strategic roadmap and migration status |
 | `CHANGELOG.md` | Record of all changes — always update before committing |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,25 @@ Looking for other Daily Demos?
 - [AAP Daily Demo hashicorp](https://github.com/ericcames/aap.dailydemo.hashicorp "AAP Daily Demo hashicorp") - ready
 - [Datacenter 1](https://github.com/ericcames/demo.datacenter "Datacenter 1") - ready<br>
 
+# Automated Bootstrap (Recommended)
+
+Use the Claude Code skills to bootstrap a fresh RHDP AAP instance automatically.
+
+**Install the skills once:**
+```bash
+claude plugins marketplace add ericcames/aap-skills
+claude plugins install aap-skills
+```
+
+| Skill | When to use |
+|-------|-------------|
+| `/aap-bootstrap` | Quietly bootstrap AAP before running a separate demo |
+| `/aap-setup-demo` | Bootstrap AAP and run the setup as a live demo story |
+
+Skills source: [github.com/ericcames/aap-skills](https://github.com/ericcames/aap-skills)
+
+---
+
 # Ansible Product Demos
 
 ![alt text](https://github.com/ericcames/aap.as.code/blob/main/images/redhatdemo.png "Catalog Item")


### PR DESCRIPTION
## Summary
- `CLAUDE.md` — bootstrap command updated to use `-i inventories/rhdp-<customer>-<demo>/`
- `CLAUDE.md` — new Claude Code Skills section with install/update instructions for `ericcames/aap-skills`
- `CLAUDE.md` — Key Files table includes `inventories/rhdp-sample-demo/`
- `README.md` — new Automated Bootstrap section at the top referencing `/aap-bootstrap` and `/aap-setup-demo`
- Closes #154

## Test plan
- [ ] Verify `CLAUDE.md` bootstrap commands work against a fresh RHDP instance
- [ ] Verify skill install commands work for a new user

🤖 Generated with [Claude Code](https://claude.com/claude-code)