### PR TITLE
docs: update README and CLAUDE.md for /aap-first-time skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Changed
+- `README.md` — added "First time here?" section and `/aap-first-time` to skills table (closes #157)
+- `CLAUDE.md` — added `/aap-first-time` to skills table, updated "Two skills" to three, updated Prerequisites to point to `/aap-first-time`, fixed hardcoded vault credential name (closes #157)
+
 ### Added
 - `CLAUDE.md` — Claude-specific guidelines covering new AAP environment setup, bootstrap playbook usage, collection install steps, key files, and project conventions
 - `ROADMAP.md` — DC1 strategic roadmap capturing architecture layers, migration sequence, phase plan, known F5 issues, and related repos

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,17 +20,18 @@ Run `playbooks/bootstrap_dev.yml` first — it creates the prerequisites automat
 
 ### Prerequisites (one-time local setup)
 
-Install the required collections locally before running the playbook:
+Run `/aap-first-time` inside Claude Code to set these up interactively, or configure manually:
+
+- `~/.ansible/ansible.cfg` with a valid Automation Hub token under `[galaxy_server.rh_certified]`
+  - Get it from: `console.redhat.com → Automation Hub → Connect to Hub → API token`
+- `~/.ansible/secrets2` containing your vault password (single line)
+- Collections installed locally:
 
 ```bash
 ANSIBLE_CONFIG=~/.ansible/ansible.cfg \
   ansible-galaxy collection install ansible.platform ansible.controller \
   -p ./collections
 ```
-
-Your `~/.ansible/ansible.cfg` must have a valid Automation Hub token under
-`[galaxy_server.rh_certified]`. Obtain it from:
-`console.redhat.com → Automation Hub → Connect to Hub → API token`
 
 ### Running the Bootstrap
 
@@ -50,7 +51,7 @@ env var and file lookups — no secrets are stored in the inventory.
 The playbook creates:
 - Automation Hub certified and validated credentials
 - Galaxy credentials associated with the Default Organization
-- Eric Ames vault credential (reads password from `~/.ansible/secrets2`)
+- Vault credential (name varies by user — reads password from `~/.ansible/secrets2`)
 - `aap.as.code` project
 - `Setup - AAP - CAC` job template
 
@@ -64,7 +65,7 @@ demo configurations via CaC.
 
 ## Claude Code Skills
 
-Two skills automate the bootstrap workflow inside Claude Code. Install them once:
+Three skills automate the bootstrap workflow inside Claude Code. Install them once:
 
 ```bash
 claude plugins marketplace add ericcames/aap-skills
@@ -73,6 +74,7 @@ claude plugins install aap-skills
 
 | Skill | Command | Purpose |
 |-------|---------|---------|
+| aap-first-time | `/aap-first-time` | One-time local setup — walks through ansible.cfg, secrets2, collections, SSH key, and vault file interactively |
 | aap-bootstrap | `/aap-bootstrap` | Collect credentials, generate inventory, run bootstrap — stops when AAP is ready |
 | aap-setup-demo | `/aap-setup-demo` | Everything above, then launches `Setup - AAP - CAC` as a live demo story |
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Looking for other Daily Demos?
 
 Use the Claude Code skills to bootstrap a fresh RHDP AAP instance automatically.
 
+**First time on a new machine? Run this first:**
+```
+/aap-first-time
+```
+It walks you through every prerequisite interactively. Already set up? Skip straight to `/aap-bootstrap`.
+
 **Install the skills once:**
 ```bash
 claude plugins marketplace add ericcames/aap-skills
@@ -26,6 +32,7 @@ claude plugins install aap-skills
 
 | Skill | When to use |
 |-------|-------------|
+| `/aap-first-time` | First time on a new machine — sets up ansible.cfg, secrets2, collections, SSH key, and vault file |
 | `/aap-bootstrap` | Quietly bootstrap AAP before running a separate demo |
 | `/aap-setup-demo` | Bootstrap AAP and run the setup as a live demo story |
 


### PR DESCRIPTION
## Summary

Brings `README.md` and `CLAUDE.md` in sync with the new `/aap-first-time` skill added to `aap-skills`.

- Closes #157

## Changes

**README.md**
- Added "First time here?" section pointing to `/aap-first-time`
- Added `/aap-first-time` to the skills table

**CLAUDE.md**
- Updated "Two skills" → "Three skills"
- Added `/aap-first-time` to the skills table
- Updated Prerequisites section to recommend `/aap-first-time` as the setup path
- Fixed hardcoded `Eric Ames vault credential` — noted name varies by user

## Test plan

- [x] README skills table has all three skills
- [x] CLAUDE.md skills table has all three skills
- [x] "First time here?" section present in README
- [x] Prerequisites section points to `/aap-first-time`
- [x] Vault credential name no longer hardcoded

🤖 Generated with [Claude Code](https://claude.com/claude-code)