### PR TITLE
feat: use my_vault and my_windows_catalog_short_description vars in bootstrap

### DIFF
--- a/inventories/rhdp-sample-demo/group_vars/all.yml
+++ b/inventories/rhdp-sample-demo/group_vars/all.yml
@@ -24,3 +24,10 @@ hub_auth_url: "https://sso.redhat.com/auth/realms/redhat-external/protocol/openi
 # Example: https://raw.githubusercontent.com/<your_org>/sourcefiles/main/vault_<your_name>.yml
 my_remote_vault: ""
 my_remote_ssh_pub_key: ""
+
+# Vault credential name — must match the credential name created in AAP and the my_vault extra var.
+# Set by running /aap-first-time.
+my_vault: ""
+
+# ServiceNow Windows catalog item short description. Override if needed.
+my_windows_catalog_short_description: "Ames AAP Windows AWS Daily Demo"

--- a/playbooks/bootstrap_dev.yml
+++ b/playbooks/bootstrap_dev.yml
@@ -70,12 +70,12 @@
               - "Automation Hub - validated"
             state: present
 
-        - name: Create Eric Ames vault credential
+        - name: Create vault credential
           ansible.controller.credential:
             controller_host: "{{ aap_hostname }}"
             controller_oauthtoken: "{{ bootstrap_token.ansible_facts.aap_token.token }}"
             validate_certs: "{{ aap_validate_certs }}"
-            name: "Eric Ames"
+            name: "{{ my_vault }}"
             organization: Default
             credential_type: "Vault"
             inputs:
@@ -107,11 +107,11 @@
             project: "aap.as.code"
             playbook: "playbooks/main.yml"
             credentials:
-              - "Eric Ames"
+              - "{{ my_vault }}"
               - "AAP Credential"
             extra_vars:
-              my_windows_catalog_short_description: "Ames AAP Windows AWS Daily Demo"
-              my_vault: "Eric Ames"
+              my_vault: "{{ my_vault }}"
+              my_windows_catalog_short_description: "{{ my_windows_catalog_short_description }}"
               my_remote_vault: "{{ my_remote_vault }}"
               my_remote_ssh_pub_key: "{{ my_remote_ssh_pub_key }}"
             ask_variables_on_launch: false


### PR DESCRIPTION
## Summary

- Adds `my_vault` and `my_windows_catalog_short_description` to the sample inventory so users can configure them per environment
- Replaces hardcoded `Eric Ames` credential name and `Ames AAP Windows AWS Daily Demo` description in `bootstrap_dev.yml` with inventory-driven variables

## Test plan

- [ ] Copy sample inventory and set `my_vault` to a custom credential name
- [ ] Run `bootstrap_dev.yml` and verify the vault credential is created with the correct name
- [ ] Verify the `Setup - AAP - CAC` job template has the correct credential and `my_vault` / `my_windows_catalog_short_description` extra vars

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)