### PR TITLE
docs: improve Automated Bootstrap section with clone, launch, and upgrade steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 - `.gitignore` — exclude `collections/` from version control (installed dependencies)
+- `README.md` — expanded Automated Bootstrap section with clone step, Claude Code launch step, upgrade path (both commands), and restart notice (closes #165)
 
 ## Previous Unreleased
 

--- a/README.md
+++ b/README.md
@@ -18,17 +18,34 @@ Looking for other Daily Demos?
 
 Use the Claude Code skills to bootstrap a fresh RHDP AAP instance automatically.
 
-**First time on a new machine? Run this first:**
+**Step 1 — Clone this repo and open it in Claude Code:**
+```bash
+git clone https://github.com/ericcames/aap.as.code.git
+cd aap.as.code
+claude
 ```
-/aap-first-time
-```
-It walks you through every prerequisite interactively. Already set up? Skip straight to `/aap-bootstrap`.
 
-**Install the skills once:**
+**Step 2 — Install (or upgrade) the aap-skills plugin:**
+
+Fresh install:
 ```bash
 claude plugins marketplace add ericcames/aap-skills
 claude plugins install aap-skills
 ```
+
+Already installed? Upgrade to the latest:
+```bash
+claude plugins marketplace update aap-skills
+claude plugins update aap-skills@aap-skills
+```
+
+> If Claude Code prompts you to restart after installing or upgrading, exit and re-run `claude` before continuing.
+
+**Step 3 — First time on a new machine? Run this inside Claude Code:**
+```
+/aap-first-time
+```
+It walks you through every prerequisite interactively. Already set up? Skip straight to `/aap-bootstrap`.
 
 | Skill | When to use |
 |-------|-------------|


### PR DESCRIPTION
## Summary

- Rewrites the Automated Bootstrap section in `README.md` as a clear 3-step flow: clone repo → install/upgrade plugin → run `/aap-first-time`
- Adds missing `git clone` and `cd aap.as.code && claude` steps so new users aren't left guessing
- Separates fresh install from upgrade commands and documents both upgrade commands correctly
- Adds restart notice after install/upgrade

## Test plan

- [ ] Read through the new section as a first-time user and confirm each step is unambiguous
- [ ] Verify the upgrade commands match what `claude plugins --help` documents

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)